### PR TITLE
Fix CI: Add workspace cleaning and Git LFS support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,17 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
+      - name: Clean workspace directory
+        run: |
+          if [ -d "${{ github.workspace }}" ]; then
+            echo "Cleaning pre-existing workspace directory..."
+            rm -rf "${{ github.workspace }}"
+          fi
+      - name: Setup Git LFS
+        uses: git-lfs/setup-git-lfs@v2
       - uses: actions/checkout@v4
+        with:
+          lfs: true
       - name: Install PostgreSQL 16
         run: |
           sudo sh -c 'echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'


### PR DESCRIPTION
## Problem

The CI workflow was failing due to two issues:

1. **Non-pristine workspace**: Git operations failed with 'directory not empty' errors
2. **Missing Git LFS support**: Large files (fonts, PDFs) failed with 'git-lfs filter-process' errors

## Solution

This PR adds three critical steps before the checkout action:

### 1. Workspace Cleaning
```yaml
- name: Clean workspace directory
  run: |
    if [ -d "${{ github.workspace }}" ]; then
      echo "Cleaning pre-existing workspace directory..."
      rm -rf "${{ github.workspace }}"
    fi
```

### 2. Git LFS Setup
```yaml
- name: Setup Git LFS
  uses: git-lfs/setup-git-lfs@v2
```

### 3. Enhanced Checkout
```yaml
- uses: actions/checkout@v4
  with:
    lfs: true
```

## Expected Results

After this fix:
- ✅ No 'directory not empty' errors
- ✅ No 'git-lfs filter-process failed' errors
- ✅ All font and PDF files properly checked out
- ✅ CI tests run successfully

## Testing

The changes follow GitHub Actions best practices and should resolve the identified failure modes without affecting existing functionality.